### PR TITLE
fix: bug in gauge deployment code

### DIFF
--- a/contracts/CurveTricryptoFactory.vy
+++ b/contracts/CurveTricryptoFactory.vy
@@ -14,9 +14,6 @@ interface TricryptoPool:
 interface ERC20:
     def decimals() -> uint256: view
 
-interface LiquidityGauge:
-    def initialize(_lp_token: address): nonpayable
-
 
 event TricryptoPoolDeployed:
     coins: address[N_COINS]
@@ -290,9 +287,7 @@ def deploy_gauge(_pool: address) -> address:
     assert self.gauge_implementation != empty(address), "Gauge implementation not set"
 
     gauge: address = create_from_blueprint(self.gauge_implementation, _pool, code_offset=3)
-
     token: address = self.pool_data[_pool].token
-    LiquidityGauge(gauge).initialize(token)
     self.pool_data[_pool].liquidity_gauge = gauge
 
     log LiquidityGaugeDeployed(_pool, gauge)

--- a/contracts/CurveTricryptoFactory.vy
+++ b/contracts/CurveTricryptoFactory.vy
@@ -282,12 +282,14 @@ def deploy_gauge(_pool: address) -> address:
     @param _pool Factory pool address to deploy a gauge for
     @return Address of the deployed gauge
     """
+    gauge_implementation: address = self.gauge_implementation
     assert self.pool_data[_pool].coins[0] != empty(address), "Unknown pool"
     assert self.pool_data[_pool].liquidity_gauge == empty(address), "Gauge already deployed"
-    assert self.gauge_implementation != empty(address), "Gauge implementation not set"
+    assert gauge_implementation != empty(address), "Gauge implementation not set"
 
-    gauge: address = create_from_blueprint(self.gauge_implementation, _pool, code_offset=3)
-    token: address = self.pool_data[_pool].token
+    gauge: address = create_from_blueprint(
+        gauge_implementation, _pool, code_offset=3
+    )
     self.pool_data[_pool].liquidity_gauge = gauge
 
     log LiquidityGaugeDeployed(_pool, gauge)


### PR DESCRIPTION
Liquidity gauges are deployed using blueprint contracts in this factory, so remove 'initialize' call.