### PR TITLE
fix: redeploy factory handler to fix bug reported by yearn

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Ethereum:
 3. Math: [0xcBFf3004a20dBfE2731543AA38599A526e0fD6eE](https://etherscan.io/address/0xcBFf3004a20dBfE2731543AA38599A526e0fD6eE)
 4. Views: [0x064253915b8449fdEFac2c4A74aA9fdF56691a31](https://etherscan.io/address/0x064253915b8449fdEFac2c4A74aA9fdF56691a31)
 5. Gauge Blueprint: [0x5fC124a161d888893529f67580ef94C2784e9233](https://etherscan.io/address/0x5fC124a161d888893529f67580ef94C2784e9233)
-6. TricryptoFactoryHandler: [0x5c57f810665E9aafb753bB9e38E6C467a6Bc4a25](https://etherscan.io/address/0x9335BF643C455478F8BE40fA20B5164b90215B80)
+6. TricryptoFactoryHandler: [0x30a4249C42be05215b6063691949710592859697](https://etherscan.io/address/0x30a4249C42be05215b6063691949710592859697)
 
 Deployed Pool:
 

--- a/contracts/main/CurveTricryptoFactoryHandler.vy
+++ b/contracts/main/CurveTricryptoFactoryHandler.vy
@@ -360,7 +360,9 @@ def get_pool_from_lp_token(_lp_token: address) -> address:
     @param _lp_token Address of the Liquidity Provider token
     @return Address of the pool
     """
-    return _lp_token
+    if self._get_n_coins(_lp_token) > 0:
+        return _lp_token
+    return empty(address)
 
 
 @external

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -19,7 +19,7 @@ DEPLOYED_CONTRACTS = {
         "views": "0x064253915b8449fdEFac2c4A74aA9fdF56691a31",
         "amm_impl": "0x66442B0C5260B92cAa9c234ECf2408CBf6b19a6f",
         "gauge_impl": "0x5fC124a161d888893529f67580ef94C2784e9233",
-        "factory_handler": "0x5c57f810665E9aafb753bB9e38E6C467a6Bc4a25",
+        "factory_handler": "0x30a4249C42be05215b6063691949710592859697",
     },
     "arbitrum:mainnet": {
         "factory": "0xbC0797015fcFc47d9C1856639CaE50D0e69FbEE8",
@@ -360,6 +360,14 @@ def update_metaregistry_integration(network, account):
     assert metaregistry.registry_length() == registry_length
     assert metaregistry.is_registered(
         "0xdc24316b9ae028f1497c275eb9192a3ea0f67022"
+    )
+
+    # if addr is not registered, do not return addr
+    assert (
+        metaregistry.get_pool_from_lp_token(
+            "0xF98B45FA17DE75FB1aD0e7aFD971b0ca00e379fC"
+        )
+        == "0x0000000000000000000000000000000000000000"
     )
 
     logger.info("Metaregistry Integrated!")


### PR DESCRIPTION
Yearn reported a bug in how the metaregistry was set up, which led to any calls for `get_pool_from_lp_token` to return the same value that was input.

To fix this, a simple check was added (to ensure an `lp_token` is registered by the factory and only then return pool address, which is the lp token address).