### PR TITLE
Update link for deployed pool on arbitrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Arbitrum:
 
 Deployed Pool:
 
-1. [TricryptoUSDC 0x7706128aFAC8875981b2412faC6C4f3053EA705f](https://etherscan.io/address/0x7706128aFAC8875981b2412faC6C4f3053EA705f)
+1. [TricryptoUSDC 0x7706128aFAC8875981b2412faC6C4f3053EA705f](https://arbiscan.io/address/0x7706128aFAC8875981b2412faC6C4f3053EA705f)
 
 ### License
 


### PR DESCRIPTION
The link was to main net instead of arbitrum. In this PR, I updated this.

By the way, I only find the usdt/weth/wbtc tricrypto pool on arbitrum (https://arbiscan.io/address/0x960ea3e3c7fb317332d990873d354e18d7645590), is this  also the tricrypto ng pool?